### PR TITLE
fix: Improve mobile hamburger menu and add prominent games section

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { blogPosts, blogCategories, BlogCategory } from '@/lib/blog-data';
 import Link from 'next/link';
 import Image from 'next/image';
@@ -10,7 +11,18 @@ import { Footer } from '@/components/layout/Footer';
 import { AdSlot } from '@/components/AdSlot';
 
 export default function BlogIndexPage() {
+    const searchParams = useSearchParams();
+    const categoryParam = searchParams.get('category');
     const [selectedCategory, setSelectedCategory] = useState<BlogCategory | 'all'>('all');
+
+    // Sync with URL param on mount and changes
+    useEffect(() => {
+        if (categoryParam && blogCategories.some(c => c.id === categoryParam)) {
+            setSelectedCategory(categoryParam as BlogCategory);
+        } else {
+            setSelectedCategory('all');
+        }
+    }, [categoryParam]);
 
     const filteredPosts = selectedCategory === 'all'
         ? blogPosts

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -218,3 +218,13 @@ a:focus-visible, button:focus-visible {
   background-color: #fed7aa;
   color: #1e3a5f;
 }
+
+/* Hide scrollbar utility */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,11 +3,12 @@ import { Footer } from '@/components/layout/Footer';
 import Link from 'next/link';
 import {
   Calculator, Brain, ArrowLeft, Percent, Divide,
-  Shapes, Scale, Star, BookOpen, GraduationCap, Sparkles, Printer, Zap
+  Shapes, Scale, Star, BookOpen, GraduationCap, Sparkles, Printer, Zap, Gamepad2
 } from 'lucide-react';
 import { FeaturedPosts } from '@/components/FeaturedPosts';
 import { HELP_TOPICS } from '@/lib/help-data';
 import { AdSlot } from '@/components/AdSlot';
+import { blogPosts } from '@/lib/blog-data';
 
 const generators = [
   {
@@ -216,6 +217,61 @@ export default function Home() {
                   </div>
                 </Link>
               ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Games Section - Prominent for Mobile */}
+        <section className="py-12 md:py-16 bg-gradient-to-br from-purple-50 via-violet-50 to-indigo-50 relative overflow-hidden">
+          <div className="absolute inset-0 dot-pattern opacity-30"></div>
+          <div className="absolute -top-20 -right-20 w-64 h-64 bg-purple-200/40 rounded-full blur-3xl"></div>
+          <div className="absolute -bottom-20 -left-20 w-64 h-64 bg-indigo-200/40 rounded-full blur-3xl"></div>
+
+          <div className="container-custom relative z-10">
+            {/* Mobile-first prominent header */}
+            <div className="text-center mb-8">
+              <div className="inline-flex items-center gap-3 bg-white/80 backdrop-blur-sm border border-purple-200 rounded-2xl px-6 py-4 shadow-lg mb-6">
+                <div className="w-14 h-14 bg-gradient-to-br from-purple-500 to-indigo-600 rounded-xl flex items-center justify-center shadow-lg shadow-purple-200">
+                  <Gamepad2 size={28} className="text-white" />
+                </div>
+                <div className="text-right">
+                  <h2 className="text-2xl md:text-3xl font-black text-slate-800">משחקים ופעילויות</h2>
+                  <p className="text-sm text-slate-500">לומדים חשבון בכיף!</p>
+                </div>
+              </div>
+            </div>
+
+            {/* Games Cards - horizontal scroll on mobile */}
+            <div className="flex gap-4 overflow-x-auto pb-4 -mx-4 px-4 md:mx-0 md:px-0 md:grid md:grid-cols-3 md:overflow-visible scrollbar-hide">
+              {blogPosts.filter(p => p.category === 'games').slice(0, 3).map((post) => (
+                <Link
+                  key={post.slug}
+                  href={`/blog/${post.slug}`}
+                  className="flex-shrink-0 w-[280px] md:w-auto bg-white rounded-2xl p-5 shadow-lg hover:shadow-xl transition-all duration-300 border border-purple-100 hover:border-purple-300 group"
+                >
+                  <div className="flex items-start gap-4">
+                    <div className="w-12 h-12 bg-gradient-to-br from-purple-100 to-indigo-100 rounded-xl flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+                      <Gamepad2 size={24} className="text-purple-600" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="font-bold text-slate-800 mb-1 line-clamp-2 group-hover:text-purple-700 transition-colors">{post.title}</h3>
+                      <p className="text-sm text-slate-500 line-clamp-2">{post.excerpt}</p>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+
+            {/* CTA for all games */}
+            <div className="text-center mt-8">
+              <Link
+                href="/blog?category=games"
+                className="inline-flex items-center gap-2 bg-gradient-to-r from-purple-600 to-indigo-600 text-white px-8 py-4 rounded-2xl font-bold text-lg shadow-xl shadow-purple-200/50 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300"
+              >
+                <Gamepad2 size={22} />
+                לכל המשחקים והפעילויות
+                <ArrowLeft size={20} />
+              </Link>
             </div>
           </div>
         </section>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { Calculator, Menu, X, ChevronDown, GraduationCap, BookOpen, Newspaper } from 'lucide-react';
+import { Calculator, Menu, X, ChevronDown, GraduationCap, BookOpen, Newspaper, Gamepad2 } from 'lucide-react';
 import { useState, useRef, useEffect } from 'react';
 
 export function Header() {
@@ -9,7 +9,21 @@ export function Header() {
     const [isGradesOpen, setIsGradesOpen] = useState(false);
     const gradesRef = useRef<HTMLDivElement>(null);
 
-    const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
+    const toggleMenu = () => {
+        setIsMenuOpen(!isMenuOpen);
+    };
+
+    // Lock body scroll when menu is open
+    useEffect(() => {
+        if (isMenuOpen) {
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.body.style.overflow = '';
+        }
+        return () => {
+            document.body.style.overflow = '';
+        };
+    }, [isMenuOpen]);
 
     // Close dropdown when clicking outside
     useEffect(() => {
@@ -34,15 +48,15 @@ export function Header() {
     return (
         <header className="bg-white/95 backdrop-blur-md border-b border-slate-100 sticky top-0 z-50 shadow-sm">
             <div className="container-custom h-16 flex items-center justify-between">
-                {/* Logo */}
-                <Link href="/" className="flex items-center gap-2.5 z-50 relative" onClick={() => setIsMenuOpen(false)}>
-                    <div className="bg-gradient-to-br from-orange-500 to-orange-600 p-2 rounded-xl text-white shadow-md shadow-orange-200">
-                        <Calculator size={22} />
-                    </div>
-                    <span className="text-lg font-black text-slate-800 hidden sm:block">
-                        דפי עבודה חכמים
-                    </span>
-                </Link>
+                {/* Mobile Menu Button - First for RTL (appears on right) */}
+                <button
+                    className="lg:hidden p-2 text-slate-600 z-50 relative hover:bg-slate-100 rounded-lg transition-colors"
+                    onClick={toggleMenu}
+                    aria-label={isMenuOpen ? 'סגור תפריט' : 'פתח תפריט'}
+                    aria-expanded={isMenuOpen}
+                >
+                    {isMenuOpen ? <X size={26} /> : <Menu size={26} />}
+                </button>
 
                 {/* Desktop Nav */}
                 <nav className="hidden lg:flex items-center gap-1">
@@ -103,68 +117,104 @@ export function Header() {
                     </Link>
                 </nav>
 
-                {/* Mobile Menu Button */}
-                <button
-                    className="lg:hidden p-2 text-slate-600 z-50 relative hover:bg-slate-100 rounded-lg transition-colors"
-                    onClick={toggleMenu}
-                    aria-label="תפריט"
-                >
-                    {isMenuOpen ? <X size={26} /> : <Menu size={26} />}
-                </button>
+                {/* Logo - Last for RTL (appears on left in desktop, but always visible) */}
+                <Link href="/" className="flex items-center gap-2.5 z-50 relative" onClick={() => setIsMenuOpen(false)}>
+                    <div className="bg-gradient-to-br from-orange-500 to-orange-600 p-2 rounded-xl text-white shadow-md shadow-orange-200">
+                        <Calculator size={22} />
+                    </div>
+                    <span className="text-lg font-black text-slate-800 hidden sm:block">
+                        דפי עבודה חכמים
+                    </span>
+                </Link>
 
-                {/* Mobile Nav Overlay */}
-                <div className={`fixed inset-0 bg-white/98 backdrop-blur-md z-40 flex flex-col items-center justify-center transition-all duration-300 ${isMenuOpen ? 'opacity-100 visible' : 'opacity-0 invisible pointer-events-none'}`}>
-                    <nav className="flex flex-col items-center gap-6 text-xl font-bold text-slate-800">
+                {/* Mobile Nav - Slide from Right */}
+                <div
+                    className={`lg:hidden fixed inset-0 z-40 transition-opacity duration-300 ${isMenuOpen ? 'opacity-100 visible' : 'opacity-0 invisible pointer-events-none'}`}
+                    onClick={() => setIsMenuOpen(false)}
+                >
+                    {/* Backdrop */}
+                    <div className="absolute inset-0 bg-black/20 backdrop-blur-sm" />
+                </div>
+                <div
+                    className={`lg:hidden fixed top-0 right-0 h-full w-[280px] max-w-[85vw] bg-white z-50 shadow-2xl transform transition-transform duration-300 ease-out ${isMenuOpen ? 'translate-x-0' : 'translate-x-full'}`}
+                >
+                    {/* Menu Header */}
+                    <div className="flex items-center justify-between p-4 border-b border-slate-100">
+                        <span className="text-lg font-black text-slate-800">תפריט</span>
+                        <button
+                            onClick={() => setIsMenuOpen(false)}
+                            className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg transition-colors"
+                            aria-label="סגור תפריט"
+                        >
+                            <X size={24} />
+                        </button>
+                    </div>
+
+                    {/* Menu Content */}
+                    <nav className="flex flex-col p-4 overflow-y-auto h-[calc(100%-65px)]">
                         <Link
                             href="/"
                             onClick={() => setIsMenuOpen(false)}
-                            className="hover:text-orange-600 transition-colors"
+                            className="flex items-center gap-3 px-4 py-3 text-lg font-bold text-slate-700 hover:bg-orange-50 hover:text-orange-600 rounded-xl transition-colors"
                         >
                             ראשי
                         </Link>
 
-                        {/* Mobile Grades */}
-                        <div className="flex flex-col items-center gap-3">
-                            <span className="text-sm font-medium text-slate-400 uppercase tracking-wider">לפי כיתה</span>
-                            <div className="flex flex-wrap justify-center gap-2">
-                                {grades.map((grade) => (
-                                    <Link
-                                        key={grade.href}
-                                        href={grade.href}
-                                        onClick={() => setIsMenuOpen(false)}
-                                        className="px-4 py-2 bg-slate-100 rounded-full text-base font-bold text-slate-600 hover:bg-orange-100 hover:text-orange-600 transition-colors"
-                                    >
-                                        {grade.label}
-                                    </Link>
-                                ))}
-                            </div>
+                        {/* Games Link - Prominent */}
+                        <Link
+                            href="/blog?category=games"
+                            onClick={() => setIsMenuOpen(false)}
+                            className="flex items-center gap-3 px-4 py-3 text-lg font-bold text-purple-700 bg-purple-50 hover:bg-purple-100 rounded-xl transition-colors mt-2"
+                        >
+                            <Gamepad2 size={22} />
+                            משחקים ופעילויות
+                        </Link>
+
+                        {/* Grades Section */}
+                        <div className="mt-4 mb-2">
+                            <span className="px-4 text-xs font-bold text-slate-400 uppercase tracking-wider">לפי כיתה</span>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2 px-2">
+                            {grades.map((grade) => (
+                                <Link
+                                    key={grade.href}
+                                    href={grade.href}
+                                    onClick={() => setIsMenuOpen(false)}
+                                    className="px-4 py-2.5 bg-slate-50 rounded-xl text-center font-bold text-slate-600 hover:bg-orange-50 hover:text-orange-600 transition-colors"
+                                >
+                                    {grade.label}
+                                </Link>
+                            ))}
                         </div>
 
-                        <Link
-                            href="/help"
-                            onClick={() => setIsMenuOpen(false)}
-                            className="flex items-center gap-2 hover:text-emerald-600 transition-colors"
-                        >
-                            <BookOpen size={20} />
-                            הסברים להורים
-                        </Link>
+                        {/* Other Links */}
+                        <div className="mt-4 border-t border-slate-100 pt-4">
+                            <Link
+                                href="/help"
+                                onClick={() => setIsMenuOpen(false)}
+                                className="flex items-center gap-3 px-4 py-3 text-base font-semibold text-slate-600 hover:bg-emerald-50 hover:text-emerald-600 rounded-xl transition-colors"
+                            >
+                                <BookOpen size={20} />
+                                הסברים להורים
+                            </Link>
 
-                        <Link
-                            href="/blog"
-                            onClick={() => setIsMenuOpen(false)}
-                            className="flex items-center gap-2 hover:text-sky-600 transition-colors"
-                        >
-                            <Newspaper size={20} />
-                            בלוג
-                        </Link>
+                            <Link
+                                href="/blog"
+                                onClick={() => setIsMenuOpen(false)}
+                                className="flex items-center gap-3 px-4 py-3 text-base font-semibold text-slate-600 hover:bg-sky-50 hover:text-sky-600 rounded-xl transition-colors"
+                            >
+                                <Newspaper size={20} />
+                                בלוג
+                            </Link>
 
-                        <Link
-                            href="/about"
-                            onClick={() => setIsMenuOpen(false)}
-                            className="hover:text-orange-600 transition-colors"
-                        >
-                            אודות
-                        </Link>
+                            <Link
+                                href="/about"
+                                onClick={() => setIsMenuOpen(false)}
+                                className="flex items-center gap-3 px-4 py-3 text-base font-semibold text-slate-600 hover:bg-orange-50 hover:text-orange-600 rounded-xl transition-colors"
+                            >
+                                אודות
+                            </Link>
+                        </div>
                     </nav>
                 </div>
             </div>


### PR DESCRIPTION
- Move hamburger menu button to right side (RTL layout convention)
- Replace full-screen overlay with slide-from-right panel menu
- Add body scroll lock when menu is open
- Add games link prominently in mobile menu
- Add games section on homepage with horizontal scroll on mobile
- Support category filter via URL params in blog page
- Add scrollbar-hide utility for clean mobile scrolling